### PR TITLE
use remotes instead of devtools

### DIFF
--- a/2-Functions-and-Importing-Data/readme.Rmd
+++ b/2-Functions-and-Importing-Data/readme.Rmd
@@ -265,8 +265,8 @@ using the data() function and a package we created for this training.
 Use the code below to obtain the data that we will use moving forward. This is 
 very similar to what is in the Excel file.
 ```{r, eval=FALSE}
-library(devtools)
-install_github("natebyers/region5air")
+library(remotes)
+install_github("fluentdata/region5air")
 library(region5air)
 data(chicago_air)
 ```


### PR DESCRIPTION
This PR changes the `devtools` package to the `remotes` package for installing from GitHub. It also changes the location of the `region5package` from `natebyers` to `fluentdata`.